### PR TITLE
Make npm installation of gifsicle work

### DIFF
--- a/compose/local/node/Dockerfile
+++ b/compose/local/node/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY ./package.json /app
 
+RUN apt-get update && apt-get install -y autoconf && apt-get install -y build-essential
 RUN npm install && npm cache clean --force
 
 ENV PATH ./node_modules/.bin/:$PATH

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -2,6 +2,7 @@ FROM node:14-buster-slim as client-builder
 
 WORKDIR /app
 COPY ./package.json /app
+RUN apt-get update && apt-get install -y autoconf && apt-get install -y build-essential
 RUN npm install && npm cache clean --force
 COPY . /app
 RUN npm run build
@@ -12,8 +13,6 @@ FROM python:3.8-buster
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update \
-  # dependencies for building Python packages
-  && apt-get install -y build-essential \
   # psycopg2 dependencies
   && apt-get install -y libpq-dev \
   # MIME magic


### PR DESCRIPTION
This seems to make it work. We need the essential build stuff and autoconf before we try to get npm working.