### PR TITLE
Turn off autoindex for media root

### DIFF
--- a/compose/production/nginx/default.conf
+++ b/compose/production/nginx/default.conf
@@ -1,14 +1,14 @@
 server {
    listen                      80; # listen on http
-   server_name                 _; # don't except a special server name (it is traefik job to already do the filter
-   client_max_body_size        1000M; # We may increase that for newtork
+   server_name                 _; # don't expect a special server name (it is traefik job to already do the filter)
+   client_max_body_size        1000M; # We may increase that for network
    set                         $cache_uri $request_uri;
 
    ignore_invalid_headers      on;
-   add_header                  Access-Control-Allow_Origin *; # That would have been unsafe if we serves js from nginx but we don't car for raw data
+   add_header                  Access-Control-Allow_Origin *; # Would be unsafe if we serve js from nginx but we don't care for raw data
 
    location /media {
-       autoindex on;
+       autoindex off;
        alias /data;
    }
 


### PR DESCRIPTION
This disables nginx from providing a directory listing for the media path. To discourage a mass download of all the data from the webserver - if we want to offer mass downloads of the data we'll do so through google cloud storage, after packaging up the data into bulky (such as daily?) chunks.
