### PR TITLE
Improve users and build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,4 +355,4 @@ celerybeat.pid
 kubernetes/katago-server/templates/env
 
 kubernetes/katago-server/values_private.yaml
-
+imagerepopath.txt

--- a/access_pod_with_shell.sh
+++ b/access_pod_with_shell.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eux
+
+if [ "$#" -ne 1 ]
+then
+    echo "USAGE: $0 PODNAME"
+fi
+
+PODNAME="$1"
+shift
+
+if [[ "$PODNAME" == *"nginx"* ]]
+then
+    kubectl exec --stdin --tty "$PODNAME" -- /bin/bash
+else
+    kubectl exec --stdin --tty "$PODNAME" -- /entrypoint /bin/bash
+fi

--- a/build_images_for_gcp.sh
+++ b/build_images_for_gcp.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eux
+
+IMAGEREPOPATH=$(cat imagerepopath.txt | tr -d '\n')
+
+docker build \
+       -t "$IMAGEREPOPATH"/katago-django:$(git describe --abbrev=7 --tags --always --first-parent) \
+       -t "$IMAGEREPOPATH"/katago-training-server/katago-django:latest \
+       . \
+       -f compose/production/django/Dockerfile
+
+docker build \
+       -t "$IMAGEREPOPATH"/katago-nginx:$(git describe --abbrev=7 --tags --always --first-parent) \
+       -t "$IMAGEREPOPATH"/katago-nginx:latest \
+       . \
+       -f compose/production/nginx/Dockerfile
+

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -33,25 +33,21 @@ COPY ./requirements /requirements
 RUN pip install --no-cache-dir -r /requirements/production.txt \
     && rm -rf /requirements
 
-COPY ./compose/production/django/entrypoint /entrypoint
+COPY --chown=django:django ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint
 RUN chmod +x /entrypoint
-RUN chown django /entrypoint
 
-COPY ./compose/production/django/start /start
+COPY --chown=django:django ./compose/production/django/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
-RUN chown django /start
 
-COPY ./compose/production/django/celery/worker/start /start-celeryworker
+COPY --chown=django:django ./compose/production/django/celery/worker/start /start-celeryworker
 RUN sed -i 's/\r$//g' /start-celeryworker
 RUN chmod +x /start-celeryworker
-RUN chown django /start-celeryworker
 
-COPY ./compose/production/django/celery/beat/start /start-celerybeat
+COPY --chown=django:django ./compose/production/django/celery/beat/start /start-celerybeat
 RUN sed -i 's/\r$//g' /start-celerybeat
 RUN chmod +x /start-celerybeat
-RUN chown django /start-celerybeat
 
 COPY ./compose/production/django/celery/flower/start /start-flower
 RUN sed -i 's/\r$//g' /start-flower
@@ -64,8 +60,7 @@ RUN chown -R django /data
 
 COPY ./.credentials /.credentials
 
-COPY --from=client-builder /app /app
-RUN chown -R django /app
+COPY --from=client-builder --chown=django:django /app /app
 
 USER django
 WORKDIR /app

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN addgroup --gid 23460 django \
-    && adduser --uid 23450 --ingroup django django
+    && adduser --uid 23450 --ingroup django --disabled-password --gecos "" django
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get update \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
 
-RUN addgroup --system django \
-    && adduser --system --ingroup django django
+RUN addgroup --gid 23460 django \
+    && adduser --uid 23450 --ingroup django django
 
 # Requirements are installed here to ensure they will be cached.
 COPY ./requirements /requirements

--- a/compose/production/nginx/Dockerfile
+++ b/compose/production/nginx/Dockerfile
@@ -1,0 +1,13 @@
+FROM nginx:stable
+
+COPY ./compose/production/nginx/nginx.conf /etc/nginx/nginx.conf
+
+# nginx docker image already defines an "nginx" user, we just need to grant
+# permissions for a few things to make it work
+RUN touch /var/run/nginx.pid && \
+  chown -R nginx:nginx /var/run/nginx.pid && \
+  chown -R nginx:nginx /var/cache/nginx && \
+  chown -R nginx:nginx /var/log/nginx && \
+  chown -R nginx:nginx /etc/nginx/conf.d
+
+USER nginx

--- a/compose/production/nginx/default.conf
+++ b/compose/production/nginx/default.conf
@@ -1,5 +1,5 @@
 server {
-   listen                      80; # listen on http
+   listen                      18080; # listen on http
    server_name                 _; # don't expect a special server name (it is traefik job to already do the filter)
    client_max_body_size        1000M; # We may increase that for network
    set                         $cache_uri $request_uri;

--- a/compose/production/nginx/nginx.conf
+++ b/compose/production/nginx/nginx.conf
@@ -1,0 +1,31 @@
+# user  nginx;  # disabled to avoid a warning since we're booting up the container as nginx, rather than as root
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/compose/production/traefik/Dockerfile
+++ b/compose/production/traefik/Dockerfile
@@ -1,5 +1,5 @@
 FROM traefik:2.2.1
-RUN mkdir -p /etc/traefik/acme
-RUN touch /etc/traefik/acme/acme.json
-RUN chmod 600 /etc/traefik/acme/acme.json
+RUN mkdir -p /etc/traefik/acme \
+  && touch /etc/traefik/acme/acme.json \
+  && chmod 600 /etc/traefik/acme/acme.json
 COPY ./compose/production/traefik/traefik_dynamic.toml /etc/traefik

--- a/kubernetes/install.sh
+++ b/kubernetes/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eux
+
+# This is how we installed at the start
+# helm install katago-server katago-server --values katago-server/values_private.yaml

--- a/kubernetes/katago-server/templates/celery-beat/deployment.yaml
+++ b/kubernetes/katago-server/templates/celery-beat/deployment.yaml
@@ -45,4 +45,7 @@ spec:
         # it fails then the process itself will exit so the container will die, since container death
         # will always be noticed.
         # livenessProbe:
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
       serviceAccountName: {{.Values.serviceAccounts.cloudSqlStorage}}

--- a/kubernetes/katago-server/templates/celery-beat/deployment.yaml
+++ b/kubernetes/katago-server/templates/celery-beat/deployment.yaml
@@ -47,5 +47,4 @@ spec:
         # livenessProbe:
         securityContext:
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
       serviceAccountName: {{.Values.serviceAccounts.cloudSqlStorage}}

--- a/kubernetes/katago-server/templates/celery-flower/deployment.yaml
+++ b/kubernetes/katago-server/templates/celery-flower/deployment.yaml
@@ -50,6 +50,9 @@ spec:
           periodSeconds: 20
           timeoutSeconds: 3
           failureThreshold: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
         resources:
           limits:
             cpu: 100m

--- a/kubernetes/katago-server/templates/celery-flower/deployment.yaml
+++ b/kubernetes/katago-server/templates/celery-flower/deployment.yaml
@@ -52,7 +52,6 @@ spec:
           failureThreshold: 5
         securityContext:
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
         resources:
           limits:
             cpu: 100m

--- a/kubernetes/katago-server/templates/celery-worker/deployment.yaml
+++ b/kubernetes/katago-server/templates/celery-worker/deployment.yaml
@@ -56,7 +56,6 @@ spec:
           subPath: {{.Values.fileserver.subPath}}
         securityContext:
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
       volumes:
       - name: django-fileserver-storage
         persistentVolumeClaim:

--- a/kubernetes/katago-server/templates/celery-worker/deployment.yaml
+++ b/kubernetes/katago-server/templates/celery-worker/deployment.yaml
@@ -54,6 +54,9 @@ spec:
         - name: django-fileserver-storage
           mountPath: /data
           subPath: {{.Values.fileserver.subPath}}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
       volumes:
       - name: django-fileserver-storage
         persistentVolumeClaim:

--- a/kubernetes/katago-server/templates/django/deployment.yaml
+++ b/kubernetes/katago-server/templates/django/deployment.yaml
@@ -58,7 +58,6 @@ spec:
           failureThreshold: 5
         securityContext:
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
         volumeMounts:
         - name: django-fileserver-storage
           mountPath: /data

--- a/kubernetes/katago-server/templates/django/deployment.yaml
+++ b/kubernetes/katago-server/templates/django/deployment.yaml
@@ -56,6 +56,9 @@ spec:
           periodSeconds: 20
           timeoutSeconds: 5
           failureThreshold: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
         volumeMounts:
         - name: django-fileserver-storage
           mountPath: /data

--- a/kubernetes/katago-server/templates/django/migrate.yaml
+++ b/kubernetes/katago-server/templates/django/migrate.yaml
@@ -27,4 +27,6 @@ spec:
         - configMapRef:
             # POSTGRES_HOST, POSTGRES_DB, POSTGRES_PORT
             name: postgres-env-config-for-hooks
+        securityContext:
+          allowPrivilegeEscalation: false
       serviceAccountName: {{.Values.serviceAccounts.cloudSqlStorage}}

--- a/kubernetes/katago-server/templates/nginx/deployment.yaml
+++ b/kubernetes/katago-server/templates/nginx/deployment.yaml
@@ -47,7 +47,6 @@ spec:
           failureThreshold: 5
         securityContext:
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
         volumeMounts:
         - name: nginx-fileserver-storage
           mountPath: /data

--- a/kubernetes/katago-server/templates/nginx/deployment.yaml
+++ b/kubernetes/katago-server/templates/nginx/deployment.yaml
@@ -45,6 +45,9 @@ spec:
           periodSeconds: 20
           timeoutSeconds: 3
           failureThreshold: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
         volumeMounts:
         - name: nginx-fileserver-storage
           mountPath: /data

--- a/kubernetes/katago-server/values.yaml
+++ b/kubernetes/katago-server/values.yaml
@@ -35,7 +35,7 @@ nginx:
   image:
     repo: TODO
     tag: TODO
-  containerPort: 80
+  containerPort: 18080
   readinessPath: healthz/
   livenessPath: healthz/
   servicePort: 80

--- a/kubernetes/katago-server/values.yaml
+++ b/kubernetes/katago-server/values.yaml
@@ -19,6 +19,16 @@ django:
   livenessPath: healthz/
   servicePort: 80
 
+nginx:
+  replicaCount: 2
+  image:
+    repo: TODO
+    tag: TODO
+  containerPort: 18080
+  readinessPath: healthz/
+  livenessPath: healthz/
+  servicePort: 80
+
 celeryWorker:
   replicaCount: 1
 celeryBeat:
@@ -29,16 +39,6 @@ celeryFlower:
   readinessPath: healthcheck/
   livenessPath: healthcheck/
   servicePort: 5555
-
-nginx:
-  replicaCount: 2
-  image:
-    repo: TODO
-    tag: TODO
-  containerPort: 18080
-  readinessPath: healthz/
-  livenessPath: healthz/
-  servicePort: 80
 
 # https://cloud.google.com/filestore/docs/accessing-fileshares
 fileserver:

--- a/kubernetes/managedcert.yaml
+++ b/kubernetes/managedcert.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: katago-managed-cert
+  namespace: serverspace
+spec:
+  domains:
+    - katagotraining.org
+    - flower.katagotraining.org

--- a/production.yml
+++ b/production.yml
@@ -105,7 +105,10 @@ services:
 
   # Serves uploaded sgfs and npz files
   nginx:
-    image: nginx
+    build:
+      context: .
+      dockerfile: ./compose/production/nginx/Dockerfile
+    image: katago_server_production_nginx
     depends_on:
       - django
     volumes:
@@ -120,7 +123,7 @@ services:
       traefik.http.routers.nginxroute.entrypoints: "websecure"
       traefik.http.routers.nginxroute.tls.certresolver: "letsencrypt"
       traefik.http.routers.nginxroute.priority: 20
-      traefik.http.services.nginxroute.loadbalancer.server.port: 80
+      traefik.http.services.nginxroute.loadbalancer.server.port: 18080
       # Define the "csrf" middleware and make nginxroute use it
       traefik.http.middlewares.csrf.headers.hostsProxyHeaders: "X-CSRFToken"
       traefik.http.routers.nginxroute.middlewares: "csrf"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,12 @@ git+git://github.com/mher/flower@e64ceb0cbda515ee9dceb862a8c4b27d253d4800#egg=fl
 uvicorn[standard]==0.12.2 # https://github.com/encode/uvicorn
 gunicorn==20.0.4  # https://github.com/benoitc/gunicorn
 
+# TODO HACK - remove this when python package maintainers fix their incompatibilities
+# https://github.com/microsoft/onefuzz/issues/284
+# urllib 1.26.0 release causes incompatibilities on packages that
+# depend on it (as of 2020-11-10)
+urllib3==1.25.11
+
 # Django
 # ------------------------------------------------------------------------------
 django==3.0.11  # pyup: < 3.1  # https://www.djangoproject.com/

--- a/upgrade_site.sh
+++ b/upgrade_site.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eux
+
+if [ "$#" -ne 1 ]
+then
+    echo "USAGE: $0 DESCRPTION"
+fi
+
+DESC="$1"
+shift
+
+(
+    cd kubernetes
+    helm upgrade katago-server katago-server --values katago-server/values_private.yaml --cleanup-on-fail --history-max 30 --description "$DESC"
+)

--- a/upload_images_for_gcp.sh
+++ b/upload_images_for_gcp.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eux
+
+IMAGEREPOPATH=$(cat imagerepopath.txt | tr -d '\n')
+
+docker push "$IMAGEREPOPATH"/katago-django:$(git describe --abbrev=7 --tags --always --first-parent)
+docker push "$IMAGEREPOPATH"/katago-django:latest
+
+docker push "$IMAGEREPOPATH"/katago-nginx:$(git describe --abbrev=7 --tags --always --first-parent)
+docker push "$IMAGEREPOPATH"/katago-nginx:latest
+


### PR DESCRIPTION
* We now run nginx as non-root, and disable privilege escalation on all containers.
* We fix django to use a hardcoded high-id non-system user and group, so that it has no special permissions and does not conflict with any user ids outside the container, especially when it writes to the filesystem.
* We backport a few minor dockerfile optimizations from the latest django cookiecutter.
* All containers are running as non root now, despite `runAsNonRoot` not working (it doesn't work in kubernetes because kubernetes doesn't support checking users by username rather than by integer).
* We add a bunch of useful scripts to the repo that I've been using, for convenience.