### PR TITLE
fix: inconsistent rating game

### DIFF
--- a/src/frontend/views/view_utils.py
+++ b/src/frontend/views/view_utils.py
@@ -110,7 +110,8 @@ def add_run_stats_context(run, context):
 
   context["num_recent_training_rows_this_run"] = default_zero(recent_games_stats["total_num_training_rows"])
   context["num_recent_training_games_this_run"] = default_zero(recent_games_stats["total_num_training_games"])
-  context["num_recent_rating_games_this_run"] = default_zero(recent_games_stats["total_num_rating_games"])
+  # Divide by 2 because each rating game appears twice, once for each network that played it
+  context["num_recent_rating_games_this_run"] = default_zero(recent_games_stats["total_num_rating_games"]) // 2
 
   context["num_networks_this_run_excluding_random"] = Network.objects.filter(run=run,is_random=False).count()
 


### PR DESCRIPTION
Ideally the change should be done in view.

```diff
  SELECT
    counts.*,
    trainings_network.name as network_name,
    trainings_network.run_id as run_id,
    trainings_network.created_at as network_created_at
  FROM
  (
    SELECT
      COALESCE(trainingcounts.network_id, ratingcounts.network_id) as network_id,
      COALESCE(trainingcounts.total_num_training_games, 0) as total_num_training_games,
      COALESCE(trainingcounts.total_num_training_rows, 0) as total_num_training_rows,
      COALESCE(ratingcounts.total_num_rating_games, 0) as total_num_rating_games,
      COALESCE(ratingcounts.total_rating_score,0.0) as total_rating_score
    FROM (
      SELECT
      black_network_id as network_id,
      count(*) as total_num_training_games,
      sum(num_training_rows) as total_num_training_rows
      FROM games_traininggame
      GROUP BY black_network_id
    ) trainingcounts
    FULL OUTER JOIN
    (
-      SELECT network_id, sum(num_games) as total_num_rating_games, sum(score) as total_rating_score
+      SELECT DISTINCT network_id, sum(num_games) as total_num_rating_games, sum(score) as total_rating_score
      FROM
      (
        (
          SELECT
          black_network_id as network_id,
          count(*) as num_games,
          sum(case when winner = 'B' then 1 when winner = 'W' then 0 else 0.5 end) as score
          FROM games_ratinggame
          GROUP BY black_network_id
        )
        UNION ALL
        (
          SELECT
          white_network_id as network_id,
          count(*) as num_games,
          sum(case when winner = 'W' then 1 when winner = 'B' then 0 else 0.5 end) as score
          FROM games_ratinggame
          GROUP BY white_network_id
        )
      ) subquery
      GROUP BY network_id
    ) ratingcounts
    ON trainingcounts.network_id = ratingcounts.network_id
  ) counts
  INNER JOIN
  trainings_network
  ON counts.network_id = trainings_network.id
```