### PR TITLE
Support alternative download link url different from storage class

### DIFF
--- a/kubernetes/katago-server/env_example/django_env_secrets.yaml
+++ b/kubernetes/katago-server/env_example/django_env_secrets.yaml
@@ -64,6 +64,9 @@ data:
   # GOOGLE_APPLICATION_CREDENTIALS: "/.credentials/gcs.json"
   # DJANGO_GCP_STORAGE_BUCKET_NAME: "katago-test-bucket"
 
+  # NETWORK_USE_PROXY_DOWNLOAD: "False"
+  # NETWORK_PROXY_DOWNLOAD_URL_BASE: "https://example.com/"
+
   # NETWORK_USE_GOOGLE_CLOUD_STORAGE: "False"
   # SGF_USE_GOOGLE_CLOUD_STORAGE: "False"
   # NPZ_USE_GOOGLE_CLOUD_STORAGE: "False"

--- a/src/apps/trainings/models/network.py
+++ b/src/apps/trainings/models/network.py
@@ -150,6 +150,37 @@ class Network(Model):
     def rating(self):
         return f"{self.elo} ± {2 * self.elo_uncertainty}"
 
+    @property
+    def model_download_url(self):
+        if not self.model_file or not self.model_file.name or len(self.model_file.name) <= 0:
+            return None
+        if settings.NETWORK_USE_PROXY_DOWNLOAD:
+            return settings.NETWORK_PROXY_DOWNLOAD_URL_BASE + self.model_file.name
+        else:
+            try:
+                url = self.model_file.url
+            except AttributeError:
+                return None
+            except NotImplementedError:
+                return self.model_file.name
+            return url
+
+    @property
+    def model_zip_download_url(self):
+        if not self.model_zip_file or not self.model_zip_file.name or len(self.model_zip_file.name) <= 0:
+            return None
+        if settings.NETWORK_USE_PROXY_DOWNLOAD:
+            return settings.NETWORK_PROXY_DOWNLOAD_URL_BASE + self.model_zip_file.name
+        else:
+            try:
+                url = self.model_zip_file.url
+            except AttributeError:
+                return None
+            except NotImplementedError:
+                return self.model_zip_file.name
+            return url
+
+
     def clean(self):
         # Allow blank file only if random
         no_model_file = not self.model_file or len(self.model_file) <= 0

--- a/src/frontend/templatehelpers/templatetags/custom_url_tags.py
+++ b/src/frontend/templatehelpers/templatetags/custom_url_tags.py
@@ -36,3 +36,10 @@ def file_download_link_html(uploaded_file_obj):
         return f'<a href="{uploaded_file_obj.url}">[{download_translated}]</a>'
     return ""
 
+@register.filter
+def download_link_html(file_url):
+    if file_url:
+        return f'<a href="{file_url}">[{download_translated}]</a>'
+    return ""
+
+

--- a/src/frontend/templates/pages/networks.html
+++ b/src/frontend/templates/pages/networks.html
@@ -55,8 +55,8 @@ Elo ratings are approximate and are *not* necessarily comparable to the Elos fro
     </td>
     <td> {{ network.created_at|isotimestr }} </td>
     <td> {{ network.rating }} - ({{ network.log_gamma_game_count|as_n_games_str }}) </td>
-    <td> {{ network.model_file|file_download_link_html|safe }} </td>
-    <td> {{ network.model_zip_file|file_download_link_html|safe }} </td>
+    <td> {{ network.model_download_url|download_link_html|safe }} </td>
+    <td> {{ network.model_zip_download_url|download_link_html|safe }} </td>
   </tr>
   {% endfor %}
 </table>

--- a/src/frontend/templates/run_stats.html
+++ b/src/frontend/templates/run_stats.html
@@ -32,11 +32,11 @@ A total of <a href="{{ networks_url }}">{{ num_networks_this_run_excluding_rando
 
 <p>
 {% if latest_network and latest_network.model_file %}
-{% trans "Latest network" %}: <a href="{{ latest_network.model_file.url }}">{{ latest_network.name }}</a>
+{% trans "Latest network" %}: <a href="{{ latest_network.model_download_url }}">{{ latest_network.name }}</a>
 {% endif %}
 <p>
 {% if strongest_confident_network and strongest_confident_network.model_file %}
-{% trans "Strongest confidently-rated network" %}: <a href="{{ strongest_confident_network.model_file.url }}">{{ strongest_confident_network.name }}</a>
+{% trans "Strongest confidently-rated network" %}: <a href="{{ strongest_confident_network.model_download_url }}">{{ strongest_confident_network.name }}</a>
 {% endif %}
 
 <h5 class="is-size-5 mt-3"> {% trans "Approximate Elo Ratings Graph" %} </h3>

--- a/src/settings/local.py
+++ b/src/settings/local.py
@@ -27,6 +27,8 @@ DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 MEDIA_ROOT = "/data"
 MEDIA_URL = "/media/"
 
+NETWORK_USE_PROXY_DOWNLOAD = False
+
 NETWORK_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 SGF_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 NPZ_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"

--- a/src/settings/production.py
+++ b/src/settings/production.py
@@ -87,6 +87,11 @@ if env.bool("NETWORK_USE_GOOGLE_CLOUD_STORAGE", default=False) or \
     GS_CACHE_CONTROL = "no-cache"
     GS_LOCATION = "uploaded/"
 
+NETWORK_USE_PROXY_DOWNLOAD = False
+if env.bool("NETWORK_USE_PROXY_DOWNLOAD"):
+    NETWORK_USE_PROXY_DOWNLOAD = True
+    NETWORK_PROXY_DOWNLOAD_URL_BASE = env("NETWORK_PROXY_DOWNLOAD_URL_BASE")
+
 NETWORK_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 if env.bool("NETWORK_USE_GOOGLE_CLOUD_STORAGE", default=False):
     NETWORK_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"

--- a/src/settings/test.py
+++ b/src/settings/test.py
@@ -39,6 +39,7 @@ NETWORK_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 SGF_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 NPZ_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 
+NETWORK_USE_PROXY_DOWNLOAD = False
 
 # Your stuff...
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Seems to work based on new pytest tests and is working in production. This alternative download link allows proxying the download behind a proper katago domain name instead of having it direct from bucket.