### PR TITLE
Fix unique integrity error

### DIFF
--- a/src/contrib/drf_exception_handler.py
+++ b/src/contrib/drf_exception_handler.py
@@ -1,0 +1,13 @@
+from django.db import IntegrityError
+from rest_framework.views import Response, exception_handler
+from rest_framework import status
+
+def custom_exception_handler(exc, context):
+    # Call REST framework's default exception handler first
+    response = exception_handler(exc, context)
+    if isinstance(exc, IntegrityError) and not response and "duplicate key value" in str(exc):
+        response = Response(
+            {"message": "Database error with duplicate key value, the uploaded data possibly already exists"},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+    return response

--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -286,6 +286,7 @@ REST_FRAMEWORK = {
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.AcceptHeaderVersioning",
     "ALLOWED_VERSIONS": ["1.2"],
     "DEFAULT_VERSION": "1.2",
+    'EXCEPTION_HANDLER': "src.contrib.drf_exception_handler.custom_exception_handler",
 }
 
 if env.bool("DJANGO_USE_REST_API_THROTTLES", default=False):


### PR DESCRIPTION
I think due to race conditions, I think it is possible that the database is rejecting a unique key violation, without any earlier validation layer catching the problem. This happened today and was reported on Sentry.

I believe this check for the django rest framework exception handler should fix it and cause it not to become an unhandled exception.