### PR TITLE
Strongest model endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .envs/.production
 
 .credentials/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 .envs/.production
 
 .credentials/*

--- a/src/apps/trainings/managers/network_queryset.py
+++ b/src/apps/trainings/managers/network_queryset.py
@@ -66,7 +66,7 @@ class NetworkQuerySet(QuerySet):
 
     def select_low_data(self, run: Run, for_training_games=False, for_rating_games=False, network_delay=None):
         filtered = self.select_networks_for_run(run, for_training_games=for_training_games, for_rating_games=for_rating_games, network_delay=network_delay)
-        low_data_networks = filtered.order_by("log_gamma_game_count","?")[:10]
+        low_data_networks = filtered.order_by("log_gamma_game_count", "?")[:10]
         if len(low_data_networks) <= 0:
             return None
         return random_weighted_choice(low_data_networks)

--- a/src/apps/trainings/managers/network_queryset.py
+++ b/src/apps/trainings/managers/network_queryset.py
@@ -1,5 +1,6 @@
 import logging
 
+import math
 import numpy as np
 import scipy.stats
 from datetime import datetime, timedelta
@@ -69,3 +70,7 @@ class NetworkQuerySet(QuerySet):
         if len(low_data_networks) <= 0:
             return None
         return random_weighted_choice(low_data_networks)
+
+    # Arbitrary reasonable cap on the uncertainty we will tolerate when trying to report a strongest network
+    def select_strongest_confident(self,run: Run,max_uncertainty_elo=100):
+        return self.objects.filter(run=run, log_gamma_uncertainty__lte=(max_uncertainty_elo / (400.0 * math.log10(math.e)))).order_by("-log_gamma_lower_confidence").first()

--- a/src/apps/trainings/managers/network_queryset.py
+++ b/src/apps/trainings/managers/network_queryset.py
@@ -72,7 +72,7 @@ class NetworkQuerySet(QuerySet):
         return random_weighted_choice(low_data_networks)
 
     # Arbitrary reasonable cap on the uncertainty we will tolerate when trying to report a strongest network
-    def select_strongest_confident(self, run: Run, max_uncertainty_elo=100):
-        filtered = self.select_networks_for_run(run=run, for_training_games=True, for_rating_games=False)
+    def select_strongest_confident(self, run: Run, for_training_games=True, for_rating_games=False, max_uncertainty_elo=100):
+        filtered = self.select_networks_for_run(run=run, for_training_games=for_training_games, for_rating_games=for_rating_games)
         not_too_uncertain_networks = filtered.filter(log_gamma_uncertainty__lte=(max_uncertainty_elo / (400.0 * math.log10(math.e))))
         return not_too_uncertain_networks.order_by("-log_gamma_lower_confidence").first()

--- a/src/apps/trainings/managers/network_queryset.py
+++ b/src/apps/trainings/managers/network_queryset.py
@@ -73,6 +73,6 @@ class NetworkQuerySet(QuerySet):
 
     # Arbitrary reasonable cap on the uncertainty we will tolerate when trying to report a strongest network
     def select_strongest_confident(self, run: Run, max_uncertainty_elo=100):
-        filtered = self.select_networks_for_run(run=run, for_training_games=False, for_rating_games=False)
+        filtered = self.select_networks_for_run(run=run, for_training_games=True, for_rating_games=False)
         not_too_uncertain_networks = filtered.filter(log_gamma_uncertainty__lte=(max_uncertainty_elo / (400.0 * math.log10(math.e))))
         return not_too_uncertain_networks.order_by("-log_gamma_lower_confidence").first()

--- a/src/apps/trainings/serializers/network.py
+++ b/src/apps/trainings/serializers/network.py
@@ -112,7 +112,6 @@ class NetworkSerializerForTasks(HyperlinkedModelSerializer):
 
     model_file = NetworkDownloadField()
 
-
 class NetworkSerializerForElo(HyperlinkedModelSerializer):
     """
     Serializer exposing only the fields of a network for plotting the network strength over time

--- a/src/apps/trainings/tests/test_api.py
+++ b/src/apps/trainings/tests/test_api.py
@@ -15,7 +15,6 @@ fake_sha256 = "12341234abcdabcd56785678abcdabcd12341234abcdabcd56785678abcdabcd"
 
 class TestGetStrongestNetwork:
     def setup_method(self):
-        self.u1 = User.objects.create_user(username="test", password="test")
         self.r1 = Run.objects.create(
             name="testrun",
             rating_game_probability=0.0,
@@ -86,11 +85,9 @@ class TestGetStrongestNetwork:
         self.n2.delete()
         self.n1.delete()
         self.r1.delete()
-        self.u1.delete()
 
     def test_get_strongest_network_anonymous(self):
         client = APIClient()
-        client.login(username="test", password="test")
         response = client.get("/api/networks/get_strongest/", {})
         data = copy.deepcopy(response.data)
         data["created_at"] = None  # Suppress timestamp for test
@@ -101,7 +98,6 @@ class TestGetStrongestNetwork:
 
 class TestGetStrongestNetworkNoSuitableNetwork:
     def setup_method(self):
-        self.u1 = User.objects.create_user(username="test", password="test")
         self.r1 = Run.objects.create(
             name="testrun",
             rating_game_probability=0.0,
@@ -124,11 +120,9 @@ class TestGetStrongestNetworkNoSuitableNetwork:
     def teardown_method(self):
         self.n1.delete()
         self.r1.delete()
-        self.u1.delete()
 
     def test_get_strongest_network_anonymous(self):
         client = APIClient()
-        client.login(username="test", password="test")
         response = client.get("/api/networks/get_strongest/", {})
         data = copy.deepcopy(response.data)
         assert str(data) == """{'error': 'No networks found for run enabled for training games.'}"""
@@ -136,15 +130,8 @@ class TestGetStrongestNetworkNoSuitableNetwork:
 
 
 class TestGetStrongestNetworkNoRun:
-    def setup_method(self):
-        self.u1 = User.objects.create_user(username="test", password="test")
-
-    def teardown_method(self):
-        self.u1.delete()
-
     def test_get_strongest_network_anonymous(self):
         client = APIClient()
-        client.login(username="test", password="test")
         response = client.get("/api/networks/get_strongest/", {})
         data = copy.deepcopy(response.data)
         assert str(data) == """{'error': 'No active run.'}"""

--- a/src/apps/trainings/tests/test_api.py
+++ b/src/apps/trainings/tests/test_api.py
@@ -1,0 +1,151 @@
+import pytest
+import copy
+
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from src.apps.runs.models import Run
+from src.apps.trainings.models import Network
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+fake_sha256 = "12341234abcdabcd56785678abcdabcd12341234abcdabcd56785678abcdabcd"
+
+class TestGetStrongestNetwork:
+    def setup_method(self):
+        self.u1 = User.objects.create_user(username="test", password="test")
+        self.r1 = Run.objects.create(
+            name="testrun",
+            rating_game_probability=0.0,
+            status="Active",
+            git_revision_hash_whitelist="abcdef123456abcdef123456abcdef1234567890\n\n1111222233334444555566667777888899990000",
+        )
+        self.n1 = Network.objects.create(
+            run=self.r1,
+            name="testrun-randomnetwork",
+            model_file="",
+            model_file_bytes=0,
+            model_file_sha256=fake_sha256,
+            log_gamma=0,
+            log_gamma_uncertainty=0.02,
+            log_gamma_lower_confidence=0 - 2 * 0.02,
+            is_random=True,
+            training_games_enabled=True
+        )
+        self.n2 = Network.objects.create(
+            run=self.r1,
+            name="net-1",
+            model_file="",
+            model_file_bytes=0,
+            model_file_sha256=fake_sha256,
+            log_gamma=35,
+            log_gamma_uncertainty=0.05,
+            log_gamma_lower_confidence=35 - 2 * 0.05,
+            training_games_enabled=True
+        )
+        self.n3 = Network.objects.create(
+            run=self.r1,
+            name="net-3",
+            model_file="",
+            model_file_bytes=0,
+            model_file_sha256=fake_sha256,
+            log_gamma=45,
+            log_gamma_uncertainty=0.07,
+            log_gamma_lower_confidence=45 - 2 * 0.07,
+            training_games_enabled=True
+        )
+        self.n4 = Network.objects.create(
+            run=self.r1,
+            name="net-4",
+            model_file="",
+            model_file_bytes=0,
+            model_file_sha256=fake_sha256,
+            log_gamma=60,
+            log_gamma_uncertainty=0.77,
+            log_gamma_lower_confidence=60 - 2 * 0.77,
+            training_games_enabled=True
+        )
+        self.n5 = Network.objects.create(
+            run=self.r1,
+            name="net-5",
+            model_file="",
+            model_file_bytes=0,
+            model_file_sha256=fake_sha256,
+            log_gamma=45.1,
+            log_gamma_uncertainty=0.45,
+            log_gamma_lower_confidence=45.1 - 2 * 0.45,
+            training_games_enabled=True
+        )
+
+    def teardown_method(self):
+        self.n5.delete()
+        self.n4.delete()
+        self.n3.delete()
+        self.n2.delete()
+        self.n1.delete()
+        self.r1.delete()
+        self.u1.delete()
+
+    def test_get_strongest_network_anonymous(self):
+        client = APIClient()
+        client.login(username="test", password="test")
+        response = client.get("/api/networks/get_strongest/", {})
+        data = copy.deepcopy(response.data)
+        data["created_at"] = None  # Suppress timestamp for test
+        data["run"] = None  # Suppress id for test
+        assert str(data) == """{'url': 'http://testserver/api/networks/net-3/', 'run': None, 'name': 'net-3', 'created_at': None, 'is_random': False, 'model_file': None, 'model_file_bytes': 0, 'model_file_sha256': '12341234abcdabcd56785678abcdabcd12341234abcdabcd56785678abcdabcd'}"""
+        assert response.status_code == 200
+
+
+class TestGetStrongestNetworkNoSuitableNetwork:
+    def setup_method(self):
+        self.u1 = User.objects.create_user(username="test", password="test")
+        self.r1 = Run.objects.create(
+            name="testrun",
+            rating_game_probability=0.0,
+            status="Active",
+            git_revision_hash_whitelist="abcdef123456abcdef123456abcdef1234567890\n\n1111222233334444555566667777888899990000",
+        )
+        self.n1 = Network.objects.create(
+            run=self.r1,
+            name="testrun-randomnetwork",
+            model_file="",
+            model_file_bytes=0,
+            model_file_sha256=fake_sha256,
+            log_gamma=0,
+            log_gamma_uncertainty=0.02,
+            log_gamma_lower_confidence=0 - 2 * 0.02,
+            is_random=True,
+            training_games_enabled=False
+        )
+
+    def teardown_method(self):
+        self.n1.delete()
+        self.r1.delete()
+        self.u1.delete()
+
+    def test_get_strongest_network_anonymous(self):
+        client = APIClient()
+        client.login(username="test", password="test")
+        response = client.get("/api/networks/get_strongest/", {})
+        data = copy.deepcopy(response.data)
+        assert str(data) == """{'error': 'No networks found for run enabled for training games.'}"""
+        assert response.status_code == 400
+
+
+class TestGetStrongestNetworkNoRun:
+    def setup_method(self):
+        self.u1 = User.objects.create_user(username="test", password="test")
+
+    def teardown_method(self):
+        self.u1.delete()
+
+    def test_get_strongest_network_anonymous(self):
+        client = APIClient()
+        client.login(username="test", password="test")
+        response = client.get("/api/networks/get_strongest/", {})
+        data = copy.deepcopy(response.data)
+        assert str(data) == """{'error': 'No active run.'}"""
+        assert response.status_code == 404

--- a/src/apps/trainings/viewsets/network.py
+++ b/src/apps/trainings/viewsets/network.py
@@ -3,7 +3,6 @@ from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from src.apps.runs.models import Run
 from src.apps.trainings.models import Network
@@ -23,6 +22,7 @@ class NetworkViewSet(viewsets.ModelViewSet):
 
     @action(detail=False, methods=["GET"])
     def newest_training(self, request):
+        # TODO: (tychota) rename this action to "get_latest". Maybe later rename to "/api/networks?filter=latest" to reduce collision with a network called "get-latest"
         current_run = Run.objects.select_current()
         if current_run is None:
             return Response({"error": "No active run."}, status=404)
@@ -39,14 +39,15 @@ class NetworkViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
     @action(detail=False, methods=["GET"])
-    def strongest(self, request):
+    def get_strongest(self, request):
+        # TODO: (tychota) Maybe later rename to "/api/networks?filter=strongest  to reduce collision with a network called "get-strongest"
         current_run = Run.objects.select_current()
         if current_run is None:
             return Response({"error": "No active run."}, status=404)
         try:
             strongest_network = Network.objects.select_strongest_confident(run=current_run)
             if not strongest_network:
-              raise Network.DoesNotExist()
+                raise Network.DoesNotExist()
         except Network.DoesNotExist:
             return Response({"error": "No networks found for run enabled for training games."}, status=400)
 

--- a/src/apps/trainings/viewsets/network.py
+++ b/src/apps/trainings/viewsets/network.py
@@ -1,15 +1,14 @@
+from django_filters import rest_framework as filters
 from rest_framework import viewsets
 from rest_framework.decorators import action
-from rest_framework.views import APIView
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
-from django_filters import rest_framework as filters
-
-from src.contrib.permission import ReadOnly
+from rest_framework.views import APIView
 
 from src.apps.runs.models import Run
 from src.apps.trainings.models import Network
 from src.apps.trainings.serializers import NetworkSerializer, NetworkSerializerForElo, NetworkSerializerForTasks
+from src.contrib.permission import ReadOnly
 
 
 class NetworkViewSet(viewsets.ModelViewSet):
@@ -31,12 +30,28 @@ class NetworkViewSet(viewsets.ModelViewSet):
         try:
             network = Network.objects.select_most_recent(current_run,for_training_games=True)
             if not network:
-                return Response({"error": "No networks found for run enabled for training games."}, status=400)
+                raise Network.DoesNotExist()
         except Network.DoesNotExist:
             return Response({"error": "No networks found for run enabled for training games."}, status=400)
 
         serializer_context = {"request": request}  # Used by serialize hyperlinked field to build and url ref
         serializer = NetworkSerializerForTasks(network, context=serializer_context)
+        return Response(serializer.data)
+
+    @action(detail=False, methods=["GET"])
+    def strongest(self, request):
+        current_run = Run.objects.select_current()
+        if current_run is None:
+            return Response({"error": "No active run."}, status=404)
+        try:
+            strongest_network = Network.objects.select_strongest_confident(run=current_run)
+            if not strongest_network:
+              raise Network.DoesNotExist()
+        except Network.DoesNotExist:
+            return Response({"error": "No networks found for run enabled for training games."}, status=400)
+
+        serializer_context = {"request": request}  # Used by serialize hyperlinked field to build and url ref
+        serializer = NetworkSerializerForTasks(strongest_network, context=serializer_context)
         return Response(serializer.data)
 
 

--- a/src/frontend/views/view_utils.py
+++ b/src/frontend/views/view_utils.py
@@ -135,11 +135,5 @@ def add_run_stats_context(run, context):
   context["num_networks_this_run_excluding_random"] = Network.objects.filter(run=run,is_random=False).count()
 
   context["latest_network"] = Network.objects.filter(run=run).order_by("-created_at").first()
-  # Arbitrary reasonable cap on the uncertainty we will tolerate when trying to report a strongest network
-  max_uncertainty_elo = 100
-  context["strongest_confident_network"] = (
-    Network
-    .objects
-    .filter(run=run, log_gamma_uncertainty__lte=(max_uncertainty_elo / (400.0 * math.log10(math.e))))
-    .order_by("-log_gamma_lower_confidence").first()
-  )
+
+  context["strongest_confident_network"] = Network.objects.select_strongest_confident(run=run)


### PR DESCRIPTION
# What 

This add a `/network/get-stongest` route that can be used by GUI to prompt update to a newer net.

**This PR is a continuation of @sanderland works https://github.com/katago/katago-server/pull/73**

# Test plan

- I added a run
![image](https://user-images.githubusercontent.com/13785185/104791214-3a528a00-579a-11eb-8f68-c5df86d6dc22.png)

- i added one net

![image](https://user-images.githubusercontent.com/13785185/104791305-a0d7a800-579a-11eb-8aef-80809d137d5b.png)

When the net is ok for training uses, the api answer 

![image](https://user-images.githubusercontent.com/13785185/104791328-b351e180-579a-11eb-8347-facb078660e1.png)

When the net is disable for training uses, the api answers

![image](https://user-images.githubusercontent.com/13785185/104791398-d1b7dd00-579a-11eb-8393-e170f62ff904.png)

**The rest of the cases are unit tested**

![image](https://user-images.githubusercontent.com/13785185/104793166-9a98fa00-57a1-11eb-9bdf-5cc4cb41c179.png)

