### PR TITLE
No limit for day and week tables for contributions page

### DIFF
--- a/src/frontend/views/contributions_view.py
+++ b/src/frontend/views/contributions_view.py
@@ -34,7 +34,6 @@ class ContributionsView(ListView):
                 total_num_rating_games=Sum("total_num_rating_games"),
             )
             .order_by("-total_num_training_rows")
-            .all()[:30]
         )
         context["top_day_user_list"] = (
             DayGameCountByUser.objects.all()
@@ -45,7 +44,6 @@ class ContributionsView(ListView):
                 total_num_rating_games=Sum("total_num_rating_games"),
             )
             .order_by("-total_num_training_rows")
-            .all()[:30]
         )
 
         return context
@@ -80,7 +78,6 @@ class ContributionsByRunView(ListView):
                 total_num_rating_games=Sum("total_num_rating_games"),
             )
             .order_by("-total_num_training_rows")
-            .all()[:30]
         )
         context["top_day_user_list"] = (
             DayGameCountByUser.objects.filter(run=self.run)
@@ -91,7 +88,6 @@ class ContributionsByRunView(ListView):
                 total_num_rating_games=Sum("total_num_rating_games"),
             )
             .order_by("-total_num_training_rows")
-            .all()[:30]
         )
 
         context["run"] = self.run


### PR DESCRIPTION
Currently we limit the length of the contributions table for the day and the week, even though we show the full table for "all time". There is no particular reason to do this, I think, since the day and week tables are in general going to be shorter than the full table, and it's still useful also to see the full list for day and week too.

Tested also at the same time as https://github.com/katago/katago-server/pull/85