### PR TITLE
Tighten validation for some npz values

### DIFF
--- a/src/apps/games/models/training_game.py
+++ b/src/apps/games/models/training_game.py
@@ -134,8 +134,8 @@ def validate_game_npzdata(training_data_file, run):
         or np.max(arrs["globalTargetsNC"][:, 19]) > 5000.0
         or np.min(arrs["globalTargetsNC"][:, 20:22]) < -5000.0
         or np.max(arrs["globalTargetsNC"][:, 20:22]) > 5000.0
-        or np.min(arrs["globalTargetsNC"][:, 23:35]) < -5.0
-        or np.max(arrs["globalTargetsNC"][:, 23:35]) > 5.0
+        or np.min(arrs["globalTargetsNC"][:, 23:35]) < 0.0
+        or np.max(arrs["globalTargetsNC"][:, 23:35]) > 2.0
         or np.min(arrs["globalTargetsNC"][:, 36:41]) < 0.0
         or np.max(arrs["globalTargetsNC"][:, 36:41]) > 1.0
         or np.min(arrs["globalTargetsNC"][:, 36:41]) < 0.0


### PR DESCRIPTION
Slightly tighten some validation for npzs. These values should never be negative, and we aren't making use of larger positive values right now.